### PR TITLE
chore: rename window settings

### DIFF
--- a/src/cSettings.json
+++ b/src/cSettings.json
@@ -5,7 +5,7 @@
 		"type": "select",
 		"category": "Main",
 		"defaultValue": "Borderless Fullscreen",
-		"options": ["Borderless Fullscreen", "Normal", "Maximized"]
+		"options": ["Borderless Fullscreen", "Windowed", "Fullscreen"]
 	},
 	"uncapFps": {
 		"name": "Uncap FPS",

--- a/src/window.rs
+++ b/src/window.rs
@@ -164,7 +164,7 @@ fn create_window(start_mode: &str) -> (HWND, WindowState) {
                 height = screen_height;
                 fullscreen_state = true;
             }
-            "Maximized" => {
+            "Fullscreen" => {
                 window_style = WS_OVERLAPPEDWINDOW | WS_VISIBLE | WS_MAXIMIZE;
                 x = 0;
                 y = 0;


### PR DESCRIPTION
## Summary
Proposing that the window settings get renamed to match standard / common terminology after it took me too long to realise how to go windowed, can't find any other references to the strings so please advise if there's alt references that need updating

## Changes
renamed strings in src/cSettings.json
renamed reference in src/window.rs

## Breaking Changes
<!---  If there are breaking changes, please state 'Yes' with some followup descriptions -->
<!--- No -->
No

## Tests
<!---  Write some notes of how this PR was tested if applicable -->
<!--- Integration tests were successful. Service was also tested by hosting it 
locally and using Basketball Beta FRVR in Facebook Instant to target it. -->
No, on mac so haven't built and tested

## Further Comments
<!---  Optional section to write any additional notes here that you might want -->
<!---  such as important things to know, how something can be replicated etc etc -->
I didn't raise an issue for this so feel free to reject and I'll just keep my fork