### PR TITLE
Glorp://... comp host

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -1,9 +1,9 @@
 use windows::Win32::UI::Input::KeyboardAndMouse::*;
 use windows::{
+    core::*,
     Win32::{
         Foundation::*, Graphics::Gdi::*, System::LibraryLoader::*, UI::WindowsAndMessaging::*,
     },
-    core::*,
 };
 
 use crate::utils;
@@ -29,6 +29,7 @@ impl Default for WindowState {
     }
 }
 
+#[derive(Clone)]
 pub struct Window {
     pub hwnd: HWND,
     pub controller: ICoreWebView2Controller4,


### PR DESCRIPTION
Added a way to host __comp matches__ using a glorp://..... host.

Example url: glorp://game?action=host-comp&mapId=gameMap0&team1Name=Team%20One&team2Name=Team%202&teamSize=1

More details will be shown in the Krunker Esports Bot.