### PR TITLE
hosting competitive matches using the url protocol

### DIFF
--- a/src/frontend/main.js
+++ b/src/frontend/main.js
@@ -1,5 +1,73 @@
 import styles from "./components/base.css";
 
+const waitForElement = (selector) => {
+  return new Promise(resolve => {
+    if (document.querySelector(selector)) {
+      return resolve(document.querySelector(selector));
+    }
+    const observer = new MutationObserver(() => {
+      if (document.querySelector(selector)) {
+        resolve(document.querySelector(selector));
+        observer.disconnect();
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  });
+};
+
+window.automateCompHost = async function(params) {
+    try {
+        const hostBtn = await waitForElement('#menuBtnHost');
+        hostBtn.click();
+        const compBtn = await waitForElement('.serverHostOp[onclick*="openHostWindow(false, 1)"]');
+        compBtn.click();
+        const mapCheckbox = await waitForElement(`#${params.mapId}`);
+        if (!mapCheckbox.checked) {
+            mapCheckbox.click();
+        }
+        const advancedTab = await waitForElement('#hstTab2');
+        advancedTab.click();
+        const team1Input = await waitForElement('#customSnameTeam1');
+        team1Input.value = params.team1Name;
+        const team2Input = await waitForElement('#customSnameTeam2');
+        team2Input.value = params.team2Name;
+        const teamSizeSelect = await waitForElement('#customStmSize');
+        teamSizeSelect.value = params.teamSize;
+        const startGameBtn = await waitForElement('#startServBtn');
+        startGameBtn.click();
+    } catch (error) {
+        console.error("glorp copm host failed: ", error);
+    }
+}
+
+window.chrome.webview.addEventListener("message", (event) => {
+    const data = event.data;
+    if (typeof data === 'string' && data.startsWith('glorp-url,')) {
+        const urlString = data.substring('glorp-url,'.length);
+        try {
+            const url = new URL(urlString);
+            const params = Object.fromEntries(url.searchParams.entries());
+            if (params.action === 'host-comp') {
+                const checkGameLoaded = setInterval(() => {
+                    if (window.hasOwnProperty('windows') && window.windows.length > 0) {
+                        clearInterval(checkGameLoaded);
+                        setTimeout(() => {
+                            window.automateCompHost(params);
+                        }, 4000);
+                    }
+                }, 100);
+            }
+        } catch(e) {
+            console.error("glorp comp host error : ", e);
+        }
+    }
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+    window.chrome.webview.postMessage('glorp-client-ready');
+}, { once: true });
+
+
 let firstLoad = true;
 window.OffCliV = true;
 window.closeClient = () => window.chrome.webview.postMessage("close");
@@ -68,7 +136,6 @@ Object.defineProperty(window, "gameLoaded", {
 
 		firstLoad = false;
 		window.windows[0].toggleType({ checked: true });
-
 
 		// append ranked and mod button to comp host ui
 		document.querySelector("#compBtnLst").innerHTML += `

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,9 +1,9 @@
 use windows::Win32::UI::Input::KeyboardAndMouse::*;
 use windows::{
+    core::*,
     Win32::{
         Foundation::*, Graphics::Gdi::*, System::LibraryLoader::*, UI::WindowsAndMessaging::*,
     },
-    core::*,
 };
 
 use crate::utils;
@@ -29,6 +29,7 @@ impl Default for WindowState {
     }
 }
 
+#[derive(Clone)]
 pub struct Window {
     pub hwnd: HWND,
     pub controller: ICoreWebView2Controller4,


### PR DESCRIPTION
Added a way to host comp matches using a glorp://..... host.

Example url: glorp://game?action=host-comp&mapId=gameMap0&team1Name=Team%20One&team2Name=Team%202&teamSize=1

More details will be shown in the Krunker Esports Bot.